### PR TITLE
added path resolution for npm packaged plugins

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var path         = require('path');
+var path       = require('path');
 
-var cfreader     = require('./configfile');
+var cfreader   = require('./configfile');
 
 module.exports = new Config();
 
@@ -17,7 +17,7 @@ function Config (root_path) {
     };
 }
 
-Config.prototype.get = function(name, type, cb, options) {
+Config.prototype.get = function (name, type, cb, options) {
     var a = this.arrange_args([name, type, cb, options]);
     if (!a[1]) a[1] = 'value';
 

--- a/config.js
+++ b/config.js
@@ -8,6 +8,7 @@ module.exports = new Config();
 
 function Config (root_path) {
     this.root_path = root_path || cfreader.config_path;
+    // console.log('root_path: ' + this.root_path);
     this.module_config = function (defaults_path, overrides_path) {
         var cfg = new Config(path.join(defaults_path, 'config'));
         if (overrides_path) {

--- a/configfile.js
+++ b/configfile.js
@@ -27,6 +27,7 @@ var config_dir_candidates = [
 
 function get_path_to_config_dir () {
     if (process.env.HARAKA) {
+        // console.log('process.env.HARAKA: ' + process.env.HARAKA);
         cfreader.config_path = path.join(process.env.HARAKA, 'config');
         return;
     }

--- a/configfile.js
+++ b/configfile.js
@@ -20,9 +20,37 @@ var regex = exports.regex = {
 
 var cfreader = exports;
 
-cfreader.config_path = process.env.HARAKA ?
-                       path.join(process.env.HARAKA, 'config')
-                     : path.join(__dirname, './config');
+var config_dirs = [
+    path.join(__dirname, 'config'),    // Haraka ./config dir
+    __dirname,                         // npm packaged plugins
+];
+
+function get_path_to_config_dir () {
+    if (process.env.HARAKA) {
+        cfreader.config_path = path.join(process.env.HARAKA, 'config');
+        return;
+    }
+
+    if (process.env.NODE_ENV === 'test') {
+        cfreader.config_path = path.join(__dirname, 'test', 'config');
+        return;
+    }
+
+    for (var i=0; i < config_dirs.length; i++) {
+        try {
+            var stat = fs.statSync(config_dirs[i]);
+            if (stat && stat.isDirectory()) {
+                cfreader.config_path = config_dirs[i];
+                return;
+            }
+        }
+        catch (ignore) {
+            console.error(ignore.message);
+        }
+    }
+}
+get_path_to_config_dir();
+// console.log('cfreader.config_path: ' + cfreader.config_path);
 
 cfreader.watch_files = true;
 cfreader._config_cache = {};

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "haraka-config",
   "license": "MIT",
   "description": "Haraka's config file loader",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "http://haraka.github.io",
   "repository": {
     "type": "git",

--- a/test/config.js
+++ b/test/config.js
@@ -9,13 +9,20 @@ var config    = require('../config');
 var cb = function () { return false; };
 var opts = { booleans: ['arg1'] };
 
-exports.module_config = {
+exports.config = {
     'new' : function (test) {
         test.expect(1);
-        var c = config.module_config('foo', 'bar');
-        test.ok(c.root_path);
+        // console.log(config);
+        test.ok(/haraka\-config\/test\/config$/.test(config.root_path));
         test.done();
-    }
+    },
+    'module_config' : function (test) {
+        test.expect(2);
+        var c = config.module_config('foo', 'bar');
+        test.equal(c.root_path, 'foo/config');
+        test.equal(c.overrides_path, 'bar/config');
+        test.done();
+    },
 };
 
 exports.arrange_args = {
@@ -157,7 +164,11 @@ var yamlRes = {
 
 function _test_get(test, name, type, callback, options, expected) {
     test.expect(1);
-    test.deepEqual(config.get(name, type, callback, options), expected);
+    var cfg = config.get(name, type, callback, options);
+    if (cfg && typeof cfg === 'object' && cfg.cached !== undefined) {
+        // delete cfg.cached;
+    }
+    test.deepEqual(cfg, expected);
     test.done();
 }
 
@@ -165,6 +176,12 @@ exports.get = {
     // config.get('name');
     'test (non-existing)' : function (test) {
         _test_get(test, 'test', null, null, null, null);
+    },
+    'test (non-existing, cached)' : function (test) {
+        test.expect(1);
+        var cfg = config.get('test', null, null);
+        test.deepEqual(cfg, null);
+        test.done();
     },
 
     // config.get('test.ini');

--- a/test/config.js
+++ b/test/config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+process.env.NODE_ENV = 'test'
+
 var path      = require('path');
 
 var config    = require('../config');
@@ -161,16 +163,13 @@ function _test_get(test, name, type, callback, options, expected) {
 
 exports.get = {
     // config.get('name');
-    'name=test (non-existing)' : function (test) {
+    'test (non-existing)' : function (test) {
         _test_get(test, 'test', null, null, null, null);
     },
 
-    // config.get('name.ini');
-    'name.ini' : function (test) {
-        _test_get(test, 'test.ini', null, null, null, { "main": {} });
-    },
+    // config.get('test.ini');
     'test.ini, no opts' : function (test) {
-        _test_get(test, '../test/config/test.ini', null, null, null, {
+        _test_get(test, 'test.ini', null, null, null, {
             main: { bool_true: 'true', bool_false: 'false', str_true: 'true', str_false: 'false' },
             sect1: { bool_true: 'true', bool_false: 'false', str_true: 'true', str_false: 'false' },
             whitespace: { str_no_trail: 'true', str_trail: 'true' },
@@ -191,7 +190,7 @@ exports.get = {
 
     // config.get('test.flat');
     'test.flat, type=' : function (test) {
-        _test_get(test, '../test/config/test.flat', null, null, null, 'line1');
+        _test_get(test, 'test.flat', null, null, null, 'line1');
     },
 
     // NOTE: the test.flat file had to be duplicated for these tests, to avoid
@@ -199,45 +198,45 @@ exports.get = {
 
     // config.get('test.flat', 'value');
     'test.flat, type=value' : function (test) {
-        _test_get(test, '../test/config/test.value', 'value', null, null, 'line1');
+        _test_get(test, 'test.value', 'value', null, null, 'line1');
     },
     // config.get('test.flat', 'list');
     'test.flat, type=list' : function (test) {
-        _test_get(test, '../test/config/test.list', 'list', null, null,
+        _test_get(test, 'test.list', 'list', null, null,
             ['line1', 'line2','line3', 'line5'] );
     },
     // config.get('test.flat', 'data');
     'test.flat, type=data' : function (test) {
-        _test_get(test, '../test/config/test.data', 'data', null, null,
+        _test_get(test, 'test.data', 'data', null, null,
             ['line1', 'line2','line3', '', 'line5'] );
     },
 
     // config.get('test.json');
     'test.json, type=' : function (test) {
-        _test_get(test, '../test/config/test.json', null, null, null, jsonRes);
+        _test_get(test, 'test.json', null, null, null, jsonRes);
     },
     // config.get('test.json', 'json');
     'test.json, type=json' : function (test) {
-        _test_get(test, '../test/config/test.json', 'json', null, null, jsonRes);
+        _test_get(test, 'test.json', 'json', null, null, jsonRes);
     },
 
     // config.get('test.yaml');
     'test.yaml, type=' : function (test) {
-        _test_get(test, '../test/config/test.yaml', null, null, null, yamlRes);
+        _test_get(test, 'test.yaml', null, null, null, yamlRes);
     },
     // config.get('test.yaml', 'yaml');
     'test.yaml, type=yaml' : function (test) {
-        _test_get(test, '../test/config/test.yaml', 'yaml', null, null, yamlRes);
+        _test_get(test, 'test.yaml', 'yaml', null, null, yamlRes);
     },
     // config.get('missing.json');
     'missing.yaml, asked for json' : function (test) {
-        _test_get(test, '../test/config/missing.json', 'json', null, null, {"matt": "waz here"});
+        _test_get(test, 'missing.json', 'json', null, null, {"matt": "waz here"});
     },
 
     // config.get('test.bin', 'binary');
     'test.bin, type=binary' : function (test) {
         test.expect(2);
-        var res = config.get('../test/config/test.binary', 'binary');
+        var res = config.get('test.binary', 'binary');
         test.equal(res.length, 120);
         test.ok(Buffer.isBuffer(res));
         test.done();

--- a/test/configfile.js
+++ b/test/configfile.js
@@ -1,5 +1,7 @@
 'use strict';
 
+process.env.NODE_ENV === 'test';
+
 var _set_up = function (done) {
     this.cfreader = require('../configfile');
     this.opts = { booleans: ['main.bool_true','main.bool_false'] };


### PR DESCRIPTION
* npm packaged plugins may drop their config files in ./  (rather than creating a config/ for a single file). If ./config doesn't exist, use ./ for config directory.