### PR TITLE
add config.getDir, loads all files in a directory

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,7 @@
 
-# 1.0.11 - 2017-0_-_
+# 1.0.11 - 2017-03-04
 
-- 
+- add config.getDir, loads all files in a directory
 
 # 1.0.10 - 2017-02-05
 

--- a/config.js
+++ b/config.js
@@ -45,20 +45,27 @@ Config.prototype.get = function (name, type, cb, options) {
     return results;
 };
 
+Config.prototype.getDir = function (name, type, opts, done) {
+    cfreader.read_dir(
+        path.resolve(this.root_path, name), type, opts, done
+    );
+};
+
 function merge_config (defaults, overrides, type) {
     if (type === 'ini' || type === 'json' || type === 'yaml') {
         return merge_struct(JSON.parse(JSON.stringify(defaults)), overrides);
     }
-    else if (Array.isArray(overrides) && Array.isArray(defaults) &&
+
+    if (Array.isArray(overrides) && Array.isArray(defaults) &&
         overrides.length > 0) {
         return overrides;
     }
-    else if (overrides != null) {
+
+    if (overrides != null) {
         return overrides;
     }
-    else {
-        return defaults;
-    }
+
+    return defaults;
 }
 
 function merge_struct (defaults, overrides) {

--- a/config.js
+++ b/config.js
@@ -45,10 +45,8 @@ Config.prototype.get = function (name, type, cb, options) {
     return results;
 };
 
-Config.prototype.getDir = function (name, type, opts, done) {
-    cfreader.read_dir(
-        path.resolve(this.root_path, name), type, opts, done
-    );
+Config.prototype.getDir = function (name, opts, done) {
+    cfreader.read_dir(path.resolve(this.root_path, name), opts, done);
 };
 
 function merge_config (defaults, overrides, type) {

--- a/configfile.js
+++ b/configfile.js
@@ -262,9 +262,10 @@ function fsWatchDir (dirPath) {
     });
 }
 
-cfreader.read_dir = function (name, type, opts, done) {
+cfreader.read_dir = function (name, opts, done) {
 
-    cfreader._read_args[name] = { type: type, opts: opts }
+    cfreader._read_args[name] = { opts: opts }
+    var type = opts.type || 'binary';
 
     isDirectory(name)
     .then((result) => {

--- a/configfile.js
+++ b/configfile.js
@@ -275,7 +275,7 @@ cfreader.read_dir = function (name, opts, done) {
         var reader = require('./readers/' + type);
         var promises = [];
         result2.forEach(function (file) {
-            promises.push(reader.loadP(path.resolve(name, file)))
+            promises.push(reader.loadPromise(path.resolve(name, file)))
         });
         return Promise.all(promises);
     })

--- a/configfile.js
+++ b/configfile.js
@@ -267,10 +267,10 @@ cfreader.read_dir = function (name, type, opts, done) {
     cfreader._read_args[name] = { type: type, opts: opts }
 
     isDirectory(name)
-    .then(function (result) {
+    .then((result) => {
         return fsReadDir(name);
     })
-    .then(function (result2) {
+    .then((result2) => {
         var reader = require('./readers/' + type);
         var promises = [];
         result2.forEach(function (file) {
@@ -278,10 +278,12 @@ cfreader.read_dir = function (name, type, opts, done) {
         });
         return Promise.all(promises);
     })
-    .catch(done)
-    .then(function (fileList) {
+    .then((fileList) => {
         // console.log(fileList);
         done(null, fileList);
+    })
+    .catch((error) => {
+        done(error);
     })
 
     if (opts.watchCb) fsWatchDir(name);

--- a/readers/binary.js
+++ b/readers/binary.js
@@ -6,11 +6,11 @@ exports.load = function (name) {
     return fs.readFileSync(name);
 };
 
-exports.loadP = function (name) {
+exports.loadPromise = function (name) {
     return new Promise(function (resolve, reject) {
         fs.readFile(name, function (err, content) {
             if (err) return reject(err);
-            resolve(content);
+            resolve({ path: name, data: content });
         });
     });
 };

--- a/readers/binary.js
+++ b/readers/binary.js
@@ -2,8 +2,17 @@
 
 var fs = require('fs');
 
-exports.load = function(name) {
+exports.load = function (name) {
     return fs.readFileSync(name);
+};
+
+exports.loadP = function (name) {
+    return new Promise(function (resolve, reject) {
+        fs.readFile(name, function (err, content) {
+            if (err) return reject(err);
+            resolve(content);
+        });
+    });
 };
 
 exports.empty = function () {

--- a/test/config.js
+++ b/test/config.js
@@ -346,7 +346,7 @@ exports.getDir = {
     },
     'loads all files in dir' : function (test) {
         test.expect(4);
-        this.config.getDir('dir', 'binary', {}, function (err, files) {
+        this.config.getDir('dir', { type: 'binary' }, function (err, files) {
             // console.log(files);
             test.equal(err, null);
             test.equal(files.length, 3);
@@ -357,7 +357,7 @@ exports.getDir = {
     },
     'errs on invalid dir' : function (test) {
         test.expect(1);
-        this.config.getDir('dirInvalid', 'binary', {}, function (err, files) {
+        this.config.getDir('dirInvalid', { type: 'binary' }, function (err, files) {
             // console.log(arguments);
             test.equal(err.code, 'ENOENT');
             test.done();
@@ -391,7 +391,8 @@ exports.getDir = {
             }
         }
         var getDir = function () {
-            self.config.getDir('dir', 'binary', { watchCb: getDir }, getDirDone);
+            var opts = { type: 'binary', watchCb: getDir };
+            self.config.getDir('dir', opts, getDirDone);
         };
         getDir();
     }

--- a/test/config.js
+++ b/test/config.js
@@ -355,6 +355,14 @@ exports.getDir = {
             test.done();
         })
     },
+    'errs on invalid dir' : function (test) {
+        test.expect(1);
+        this.config.getDir('dirInvalid', 'binary', {}, function (err, files) {
+            // console.log(arguments);
+            test.equal(err.code, 'ENOENT');
+            test.done();
+        })
+    },
     'reloads when file in dir is touched' : function (test) {
         test.expect(6);
         var self = this;

--- a/test/config.js
+++ b/test/config.js
@@ -350,8 +350,8 @@ exports.getDir = {
             // console.log(files);
             test.equal(err, null);
             test.equal(files.length, 3);
-            test.equal(files[0].toString(), 'contents1\n');
-            test.equal(files[2].toString(), 'contents3\n');
+            test.equal(files[0].data, 'contents1\n');
+            test.equal(files[2].data, 'contents3\n');
             test.done();
         })
     },
@@ -376,8 +376,8 @@ exports.getDir = {
                 // console.log(files);
                 test.equal(err, null);
                 test.equal(files.length, 3);
-                test.equal(files[0].toString(), 'contents1\n');
-                test.equal(files[2].toString(), 'contents3\n');
+                test.equal(files[0].data, 'contents1\n');
+                test.equal(files[2].data, 'contents3\n');
                 fs.writeFile(tmpFile, 'contents4\n', function (err, res) {
                     test.equal(err, null);
                     // console.log('file touched, waiting for callback');
@@ -386,7 +386,7 @@ exports.getDir = {
                 return;
             }
             if (callCount === 2) {
-                test.equal(files[3].toString(), 'contents4\n');
+                test.equal(files[3].data, 'contents4\n');
                 test.done();
             }
         }

--- a/test/config.js
+++ b/test/config.js
@@ -203,7 +203,7 @@ var yamlRes = {
     }
 };
 
-function _test_get(test, name, type, callback, options, expected) {
+function _test_get (test, name, type, callback, options, expected) {
     test.expect(1);
     var config = require('../config');
     var cfg = config.get(name, type, callback, options);
@@ -334,4 +334,19 @@ exports.merged = {
         test.equal(lc.get('test.flat'), 'flatoverrode');
         test.done();
     },
+}
+
+exports.getDir = {
+    'setUp' : setUp,
+    'loads all files in dir' : function (test) {
+        test.expect(4);
+        this.config.getDir('dir', 'binary', {}, function (err, files) {
+            // console.log(files);
+            test.equal(err, null);
+            test.equal(files.length, 3);
+            test.equal(files[0].toString(), 'contents1\n');
+            test.equal(files[2].toString(), 'contents3\n');
+            test.done();
+        })
+    }
 }

--- a/test/config.js
+++ b/test/config.js
@@ -2,6 +2,7 @@
 
 process.env.NODE_ENV = 'test'
 
+var fs   = require('fs');
 var path = require('path');
 
 var cb = function () { return false; };
@@ -338,6 +339,11 @@ exports.merged = {
 
 exports.getDir = {
     'setUp' : setUp,
+    'tearDown' : function (done) {
+        fs.unlink(path.resolve('test','config','dir', '4.ext'), function () {
+            done();
+        })
+    },
     'loads all files in dir' : function (test) {
         test.expect(4);
         this.config.getDir('dir', 'binary', {}, function (err, files) {
@@ -348,5 +354,37 @@ exports.getDir = {
             test.equal(files[2].toString(), 'contents3\n');
             test.done();
         })
+    },
+    'reloads when file in dir is touched' : function (test) {
+        test.expect(6);
+        var self = this;
+        var tmpFile = path.resolve('test','config','dir', '4.ext');
+        var callCount = 0;
+        var getDirDone = function (err, files) {
+            // console.log('Loading: test/config/dir');
+            if (err) console.error(err);
+            callCount++;
+            if (callCount === 1) {
+                // console.log(files);
+                test.equal(err, null);
+                test.equal(files.length, 3);
+                test.equal(files[0].toString(), 'contents1\n');
+                test.equal(files[2].toString(), 'contents3\n');
+                fs.writeFile(tmpFile, 'contents4\n', function (err, res) {
+                    test.equal(err, null);
+                    // console.log('file touched, waiting for callback');
+                    // console.log(res);
+                });
+                return;
+            }
+            if (callCount === 2) {
+                test.equal(files[3].toString(), 'contents4\n');
+                test.done();
+            }
+        }
+        var getDir = function () {
+            self.config.getDir('dir', 'binary', { watchCb: getDir }, getDirDone);
+        };
+        getDir();
     }
 }

--- a/test/config/dir/1.ext
+++ b/test/config/dir/1.ext
@@ -1,0 +1,1 @@
+contents1

--- a/test/config/dir/2.ext
+++ b/test/config/dir/2.ext
@@ -1,0 +1,1 @@
+contents2

--- a/test/config/dir/3.ext
+++ b/test/config/dir/3.ext
@@ -1,0 +1,1 @@
+contents3


### PR DESCRIPTION
this is in preparation for haraka/Haraka#1828

- api for getDir is a node callback
- unlike `get`, `getDir` is async and returns nothing. The results are in the callback.
- internally, getDir is implemented entirely with promises
- [x] dir watching