### PR TITLE
process.env.HARAKA_TEST_DIR

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 
 ## 1.0.14 - 2017-09-19
 
+- add __dirname/../../config to config_dir_candidates for haraka/Haraka/tests/*
 - sync process.env.HARAKA_TEST_DIR from haraka/Haraka/config
 - eslint no-var updates #25
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,22 +1,27 @@
 
-# 1.0.13 - 2017-06-16
+## 1.0.14 - 2017-09-19
+
+- sync process.env.HARAKA_TEST_DIR from haraka/Haraka/config
+- eslint no-var updates #25
+
+## 1.0.13 - 2017-06-16
 
 - lint updates for eslint 4
 
-# 1.0.12 - 2017-05-21
+## 1.0.12 - 2017-05-21
 
 - unref() the setInterval so that Haraka can gracefully exit
 
-# 1.0.11 - 2017-03-04
+## 1.0.11 - 2017-03-04
 
 - add config.getDir, loads all files in a directory
 
-# 1.0.10 - 2017-02-05
+## 1.0.10 - 2017-02-05
 
-- log error vs throw on bad YAML  
+- log error vs throw on bad YAML
 - fix appveyor badge URL
 
-# 1.0.9 - 2017-01-27
+## 1.0.9 - 2017-01-27
 
 - config cache fix (see haraka/Haraka#1738)
 - config: add overrides handling (sync with Haraka)
@@ -25,24 +30,24 @@
 - use haraka-eslint plugin (vs local copy of .eslintrc)
 - lint updates
 
-# 1.0.8 - 2017-01-02
+## 1.0.8 - 2017-01-02
 
 - version bump, lint updates & sync
 - lint fixes
 
-# 1.0.7 - 2016-11-17
+## 1.0.7 - 2016-11-17
 
 - update tests for appveyor (Windows) compatibility #9
 
-# 1.0.6 - 2016-11-10
+## 1.0.6 - 2016-11-10
 
 - handle invalid .ini lines properly (skip them)
 
-# 1.0.5 - 2016-10-25
+## 1.0.5 - 2016-10-25
 
 - do not leave behind a `*` section in config (due to wildcard boolean)
 
-# 1.0.3
+## 1.0.3
 
 - added wildcard boolean support
 - reduce node required 4.3 -> 0.10.43

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 1.0.{build}
 
 environment:
-  nodejs_version: "4"
+  nodejs_version: "6"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/config.js
+++ b/config.js
@@ -14,7 +14,11 @@ function Config (root_path, no_overrides) {
             cfg.overrides_path = path.join(overrides_path, 'config');
         }
         return cfg;
-    };
+    }
+    if (process.env.HARAKA_TEST_DIR) {
+        this.root_path = path.join(process.env.HARAKA_TEST_DIR, 'config');
+        return;
+    }
     if (process.env.HARAKA && !no_overrides) {
         this.overrides_path = root_path || cfreader.config_path;
         this.root_path = path.join(process.env.HARAKA, 'config');
@@ -59,9 +63,7 @@ function merge_config (defaults, overrides, type) {
         return overrides;
     }
 
-    if (overrides != null) {
-        return overrides;
-    }
+    if (overrides != null) return overrides;
 
     return defaults;
 }

--- a/configfile.js
+++ b/configfile.js
@@ -30,7 +30,7 @@ cfreader._sedation_timers = {};
 cfreader._overrides = {};
 
 let config_dir_candidates = [
-    // these work when this file is required as './config.js'
+    // these work when this file is loaded as require('./config.js')
     path.join(__dirname, 'config'),    // Haraka ./config dir
     __dirname,                         // npm packaged plugins
 ];
@@ -48,14 +48,11 @@ function get_path_to_config_dir () {
         return;
     }
 
-    // these work when this file is required as 'haraka-config'
+    // these work when this is loaded with require('haraka-config')
     if (/node_modules\/haraka-config$/.test(__dirname)) {
         config_dir_candidates = [
-            // haraka/Haraka/tests/*
-            path.resolve(__dirname, '..', '..', 'config'),
-
-            // npm packaged modules
-            path.resolve(__dirname, '..', '..'),
+            path.join(__dirname, '..', '..', 'config'),  // haraka/Haraka/*
+            path.join(__dirname, '..', '..'),            // npm packaged modules
         ]
     }
 
@@ -277,16 +274,16 @@ cfreader.read_dir = function (name, opts, done) {
         .then((result) => {
             return fsReadDir(name);
         })
-        .then((result2) => {
+        .then((fileList) => {
             const reader = require('./readers/' + type);
             const promises = [];
-            result2.forEach(function (file) {
+            fileList.forEach((file) => {
                 promises.push(reader.loadPromise(path.resolve(name, file)))
             });
             return Promise.all(promises);
         })
         .then((fileList) => {
-        // console.log(fileList);
+            // console.log(fileList);
             done(null, fileList);
         })
         .catch((error) => {

--- a/configfile.js
+++ b/configfile.js
@@ -29,7 +29,8 @@ cfreader._enoent_files = {};
 cfreader._sedation_timers = {};
 cfreader._overrides = {};
 
-const config_dir_candidates = [
+let config_dir_candidates = [
+    // these work when this file is required as './config.js'
     path.join(__dirname, 'config'),    // Haraka ./config dir
     __dirname,                         // npm packaged plugins
 ];
@@ -47,10 +48,15 @@ function get_path_to_config_dir () {
         return;
     }
 
+    // these work when this file is required as 'haraka-config'
     if (/node_modules\/haraka-config$/.test(__dirname)) {
-        // loaded by a npm packaged module
-        cfreader.config_path = path.resolve(__dirname, '..', '..');
-        return;
+        config_dir_candidates = [
+            // haraka/Haraka/tests/*
+            path.resolve(__dirname, '..', '..', 'config'),
+
+            // npm packaged modules
+            path.resolve(__dirname, '..', '..'),
+        ]
     }
 
     for (let i=0; i < config_dir_candidates.length; i++) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "haraka-config",
   "license": "MIT",
   "description": "Haraka's config file loader",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "homepage": "http://haraka.github.io",
   "repository": {
     "type": "git",
@@ -11,7 +11,7 @@
   },
   "main": "config.js",
   "engines": {
-    "node": ">= 4"
+    "node": ">= 6"
   },
   "dependencies": {
     "js-yaml": "^3.5.3"
@@ -23,13 +23,13 @@
     "nodeunit": "*"
   },
   "bugs": {
-    "mail": "helpme@gmail.com",
+    "mail": "haraka.mail@gmail.com",
     "url": "https://github.com/haraka/haraka-config/issues"
   },
   "scripts": {
     "test": "./run_tests",
-    "lint": "./node_modules/.bin/eslint *.js test/**/*.js",
-    "lintfix": "./node_modules/.bin/eslint --fix *.js test/**/*.js",
+    "lint": "./node_modules/.bin/eslint *.js test/*.js test/*/*.js",
+    "lintfix": "./node_modules/.bin/eslint --fix *.js test/*.js test/*/*.js",
     "cover": "./node_modules/.bin/istanbul cov run_tests"
   }
 }

--- a/test/config.js
+++ b/test/config.js
@@ -2,11 +2,11 @@
 
 process.env.NODE_ENV = 'test'
 
-var fs   = require('fs');
-var path = require('path');
+const fs   = require('fs');
+const path = require('path');
 
-var cb = function () { return false; };
-var opts = { booleans: ['arg1'] };
+const cb = function () { return false; };
+const opts = { booleans: ['arg1'] };
 
 function clearRequireCache () {
     // node_unit runs all the tests in the same process, so the process.env
@@ -36,7 +36,7 @@ exports.config = {
     },
     'module_config' : function (test) {
         test.expect(2);
-        var c = this.config.module_config('foo', 'bar');
+        const c = this.config.module_config('foo', 'bar');
         test.equal(c.root_path, path.join('foo','config'));
         test.equal(c.overrides_path, path.join('bar','config'));
         test.done();
@@ -48,7 +48,7 @@ exports.config_path = {
         test.expect(1);
         process.env.HARAKA = '/tmp';
         clearRequireCache();
-        var config = require('../config');
+        const config = require('../config');
         // console.log(config);
         test.equal(config.root_path, path.join('/tmp','config'));
         test.done();
@@ -58,9 +58,9 @@ exports.config_path = {
         process.env.HARAKA = '';
         process.env.NODE_ENV = 'not-test';
         clearRequireCache();
-        var config = require('../config');
+        const config = require('../config');
         // ./config doesn't exist so path will be resolved ./
-        test.ok(/haraka\-config$/.test(config.root_path));
+        test.ok(/haraka-config$/.test(config.root_path));
         process.env.NODE_ENV = 'test';
         test.done();
     },
@@ -174,13 +174,13 @@ exports.arrange_args = {
     },
 };
 
-var jsonRes = {
+const jsonRes = {
     matt: 'waz here',
     array: [ 'has an element' ],
     objecty: { 'has a property': 'with a value' }
 };
 
-var yamlRes = {
+const yamlRes = {
     main: {
         bool_true: true,
         bool_false: false,
@@ -206,8 +206,8 @@ var yamlRes = {
 
 function _test_get (test, name, type, callback, options, expected) {
     test.expect(1);
-    var config = require('../config');
-    var cfg = config.get(name, type, callback, options);
+    const config = require('../config');
+    const cfg = config.get(name, type, callback, options);
     test.deepEqual(cfg, expected);
     test.done();
 }
@@ -220,7 +220,7 @@ exports.get = {
     },
     'test (non-existing, cached)' : function (test) {
         test.expect(1);
-        var cfg = this.config.get('test', null, null);
+        const cfg = this.config.get('test', null, null);
         test.deepEqual(cfg, null);
         test.done();
     },
@@ -296,7 +296,7 @@ exports.get = {
     // config.get('test.bin', 'binary');
     'test.bin, type=binary' : function (test) {
         test.expect(2);
-        var res = this.config.get('test.binary', 'binary');
+        const res = this.config.get('test.binary', 'binary');
         test.equal(res.length, 120);
         test.ok(Buffer.isBuffer(res));
         test.done();
@@ -307,28 +307,28 @@ exports.merged = {
     'setUp' : setUp,
     'before_merge' : function (test) {
         test.expect(1);
-        var lc = this.config.module_config(
+        const lc = this.config.module_config(
             path.join('test','default')
         );
         test.deepEqual(lc.get('test.ini'),
             { main: {}, defaults: { one: 'one', two: 'two' } }
-            );
+        );
         test.done();
     },
     'after_merge': function (test) {
         test.expect(1);
-        var lc = this.config.module_config(
+        const lc = this.config.module_config(
             path.join('test','default'),
             path.join('test','override')
         );
         test.deepEqual(lc.get('test.ini'),
             { main: {}, defaults: { one: 'three', two: 'four' } }
-            );
+        );
         test.done();
     },
     'flat overridden' : function (test) {
         test.expect(1);
-        var lc = this.config.module_config(
+        const lc = this.config.module_config(
             path.join('test','default'),
             path.join('test','override')
         );
@@ -365,10 +365,10 @@ exports.getDir = {
     },
     'reloads when file in dir is touched' : function (test) {
         test.expect(6);
-        var self = this;
-        var tmpFile = path.resolve('test','config','dir', '4.ext');
-        var callCount = 0;
-        var getDirDone = function (err, files) {
+        const self = this;
+        const tmpFile = path.resolve('test','config','dir', '4.ext');
+        let callCount = 0;
+        const getDirDone = function (err, files) {
             // console.log('Loading: test/config/dir');
             if (err) console.error(err);
             callCount++;
@@ -378,8 +378,8 @@ exports.getDir = {
                 test.equal(files.length, 3);
                 test.equal(files[0].data, 'contents1\n');
                 test.equal(files[2].data, 'contents3\n');
-                fs.writeFile(tmpFile, 'contents4\n', function (err, res) {
-                    test.equal(err, null);
+                fs.writeFile(tmpFile, 'contents4\n', function (err2, res) {
+                    test.equal(err2, null);
                     // console.log('file touched, waiting for callback');
                     // console.log(res);
                 });
@@ -390,10 +390,10 @@ exports.getDir = {
                 test.done();
             }
         }
-        var getDir = function () {
-            var opts = { type: 'binary', watchCb: getDir };
-            self.config.getDir('dir', opts, getDirDone);
-        };
+        function getDir () {
+            const opts2 = { type: 'binary', watchCb: getDir };
+            self.config.getDir('dir', opts2, getDirDone);
+        }
         getDir();
     }
 }

--- a/test/configfile.js
+++ b/test/configfile.js
@@ -2,7 +2,7 @@
 
 process.env.NODE_ENV === 'test';
 
-var _set_up = function (done) {
+const _set_up = function (done) {
     this.cfreader = require('../configfile');
     this.opts = { booleans: ['main.bool_true','main.bool_false'] };
     done();
@@ -13,75 +13,75 @@ exports.load_config = {
     'non-exist.ini empty' : function (test) {
         test.expect(1);
         test.deepEqual(
-                this.cfreader.load_config('non-exist.ini','ini'),
-                { main: { } }
-                );
+            this.cfreader.load_config('non-exist.ini','ini'),
+            { main: { } }
+        );
         test.done();
     },
     'non-exist.ini boolean' : function (test) {
         test.expect(1);
         test.deepEqual(
-                this.cfreader.load_config('non-exist.ini', 'ini',
-                    { booleans: ['reject']}),
-                { main: { reject: false } }
-                );
+            this.cfreader.load_config('non-exist.ini', 'ini',
+                { booleans: ['reject']}),
+            { main: { reject: false } }
+        );
         test.done();
     },
     'non-exist.ini boolean true default' : function (test) {
         test.expect(3);
         test.deepEqual(
-                this.cfreader.load_config('non-exist.ini', 'ini',
-                    { booleans: ['+reject']}),
-                { main: { reject: true } }
-                );
+            this.cfreader.load_config('non-exist.ini', 'ini',
+                { booleans: ['+reject']}),
+            { main: { reject: true } }
+        );
         test.deepEqual(
-                this.cfreader.load_config('non-exist.ini', 'ini',
-                    { booleans: ['+main.reject']}),
-                { main: { reject: true } }
-                );
+            this.cfreader.load_config('non-exist.ini', 'ini',
+                { booleans: ['+main.reject']}),
+            { main: { reject: true } }
+        );
         test.deepEqual(
-                this.cfreader.load_config('non-exist.ini', 'ini',
-                    { booleans: ['main.+reject']}),
-                { main: { reject: true } }
-                );
+            this.cfreader.load_config('non-exist.ini', 'ini',
+                { booleans: ['main.+reject']}),
+            { main: { reject: true } }
+        );
         test.done();
     },
     'non-exist.ini boolean false default' : function (test) {
         test.expect(3);
         test.deepEqual(
-                this.cfreader.load_config('non-exist.ini', 'ini',
-                    { booleans: ['-reject']}),
-                { main: { reject: false } }
-                );
+            this.cfreader.load_config('non-exist.ini', 'ini',
+                { booleans: ['-reject']}),
+            { main: { reject: false } }
+        );
         test.deepEqual(
-                this.cfreader.load_config('non-exist.ini', 'ini',
-                    { booleans: ['-main.reject']}),
-                { main: { reject: false } }
-                );
+            this.cfreader.load_config('non-exist.ini', 'ini',
+                { booleans: ['-main.reject']}),
+            { main: { reject: false } }
+        );
         test.deepEqual(
-                this.cfreader.load_config('non-exist.ini', 'ini',
-                    { booleans: ['main.-reject']}),
-                { main: { reject: false } }
-                );
+            this.cfreader.load_config('non-exist.ini', 'ini',
+                { booleans: ['main.-reject']}),
+            { main: { reject: false } }
+        );
         test.done();
     },
     'non-exist.ini boolean false default, section' : function (test) {
         test.expect(2);
         test.deepEqual(
-                this.cfreader.load_config('non-exist.ini', 'ini',
-                    { booleans: ['-reject.boolf']}),
-                { main: { }, reject: {boolf: false} }
-                );
+            this.cfreader.load_config('non-exist.ini', 'ini',
+                { booleans: ['-reject.boolf']}),
+            { main: { }, reject: {boolf: false} }
+        );
         test.deepEqual(
-                this.cfreader.load_config('non-exist.ini', 'ini',
-                    { booleans: ['+reject.boolt']}),
-                { main: { }, reject: {boolt: true} }
-                );
+            this.cfreader.load_config('non-exist.ini', 'ini',
+                { booleans: ['+reject.boolt']}),
+            { main: { }, reject: {boolt: true} }
+        );
         test.done();
     },
     'test.ini, no opts' : function (test) {
         test.expect(4);
-        var r = this.cfreader.load_config('test/config/test.ini','ini');
+        const r = this.cfreader.load_config('test/config/test.ini','ini');
         test.strictEqual(r.main.bool_true, 'true');
         test.strictEqual(r.main.bool_false, 'false');
         test.strictEqual(r.main.str_true, 'true');
@@ -90,7 +90,7 @@ exports.load_config = {
     },
     'test.ini, opts' : function (test) {
         test.expect(4);
-        var r = this.cfreader.load_config('test/config/test.ini', 'ini', this.opts);
+        const r = this.cfreader.load_config('test/config/test.ini', 'ini', this.opts);
         test.strictEqual(r.main.bool_true, true);
         test.strictEqual(r.main.bool_false, false);
         test.strictEqual(r.main.str_true, 'true');
@@ -99,7 +99,7 @@ exports.load_config = {
     },
     'test.ini, sect1, opts' : function (test) {
         test.expect(4);
-        var r = this.cfreader.load_config('test/config/test.ini', 'ini', {
+        const r = this.cfreader.load_config('test/config/test.ini', 'ini', {
             booleans: ['sect1.bool_true','sect1.bool_false']
         });
         test.strictEqual(r.sect1.bool_true, true);
@@ -110,7 +110,7 @@ exports.load_config = {
     },
     'test.ini, sect1, opts, w/defaults' : function (test) {
         test.expect(6);
-        var r = this.cfreader.load_config('test/config/test.ini', 'ini', {
+        const r = this.cfreader.load_config('test/config/test.ini', 'ini', {
             booleans: [
                 '+sect1.bool_true','-sect1.bool_false',
                 '+sect1.bool_true_default', 'sect1.-bool_false_default'
@@ -126,31 +126,31 @@ exports.load_config = {
     },
     'test.ini, funnychars, /' : function (test) {
         test.expect(1);
-        var r = this.cfreader.load_config('test/config/test.ini');
+        const r = this.cfreader.load_config('test/config/test.ini');
         test.strictEqual(r.funnychars['results.auth/auth_base.fail'], 'fun');
         test.done();
     },
     'test.ini, funnychars, _' : function (test) {
         test.expect(1);
-        var r = this.cfreader.load_config('test/config/test.ini');
+        const r = this.cfreader.load_config('test/config/test.ini');
         test.strictEqual(r.funnychars['results.auth/auth_base.fail'], 'fun');
         test.done();
     },
     'test.ini, ipv6 addr, :' : function (test) {
         test.expect(1);
-        var r = this.cfreader.load_config('test/config/test.ini');
+        const r = this.cfreader.load_config('test/config/test.ini');
         test.ok( '2605:ae00:329::2' in r.has_ipv6 );
         test.done();
     },
     'test.ini, empty value' : function (test) {
         test.expect(1);
-        var r = this.cfreader.load_config('test/config/test.ini');
+        const r = this.cfreader.load_config('test/config/test.ini');
         test.deepEqual({ first: undefined, second: undefined}, r.empty_values);
         test.done();
     },
-    'test.ini, array' : function(test){
+    'test.ini, array' : function (test){
         test.expect(2);
-        var r = this.cfreader.load_config('test/config/test.ini');
+        const r = this.cfreader.load_config('test/config/test.ini');
         test.deepEqual(['first_host', 'second_host', 'third_host'], r.array_test.hostlist);
         test.deepEqual([123, 456, 789], r.array_test.intlist);
         test.done();
@@ -161,56 +161,56 @@ exports.get_filetype_reader  = {
     setUp: _set_up,
     'binary': function (test) {
         test.expect(2);
-        var reader = this.cfreader.get_filetype_reader('binary');
+        const reader = this.cfreader.get_filetype_reader('binary');
         test.equal(typeof reader.load, 'function');
         test.equal(typeof reader.empty, 'function');
         test.done();
     },
     'flat': function (test) {
         test.expect(2);
-        var reader = this.cfreader.get_filetype_reader('flat');
+        const reader = this.cfreader.get_filetype_reader('flat');
         test.equal(typeof reader.load, 'function');
         test.equal(typeof reader.empty, 'function');
         test.done();
     },
     'json': function (test) {
         test.expect(2);
-        var reader = this.cfreader.get_filetype_reader('json');
+        const reader = this.cfreader.get_filetype_reader('json');
         test.equal(typeof reader.load, 'function');
         test.equal(typeof reader.empty, 'function');
         test.done();
     },
     'ini': function (test) {
         test.expect(2);
-        var reader = this.cfreader.get_filetype_reader('ini');
+        const reader = this.cfreader.get_filetype_reader('ini');
         test.equal(typeof reader.load, 'function');
         test.equal(typeof reader.empty, 'function');
         test.done();
     },
     'yaml': function (test) {
         test.expect(2);
-        var reader = this.cfreader.get_filetype_reader('yaml');
+        const reader = this.cfreader.get_filetype_reader('yaml');
         test.equal(typeof reader.load, 'function');
         test.equal(typeof reader.empty, 'function');
         test.done();
     },
     'value': function (test) {
         test.expect(2);
-        var reader = this.cfreader.get_filetype_reader('value');
+        const reader = this.cfreader.get_filetype_reader('value');
         test.equal(typeof reader.load, 'function');
         test.equal(typeof reader.empty, 'function');
         test.done();
     },
     'list': function (test) {
         test.expect(2);
-        var reader = this.cfreader.get_filetype_reader('list');
+        const reader = this.cfreader.get_filetype_reader('list');
         test.equal(typeof reader.load, 'function');
         test.equal(typeof reader.empty, 'function');
         test.done();
     },
     'data': function (test) {
         test.expect(2);
-        var reader = this.cfreader.get_filetype_reader('data');
+        const reader = this.cfreader.get_filetype_reader('data');
         test.equal(typeof reader.load, 'function');
         test.equal(typeof reader.empty, 'function');
         test.done();
@@ -220,60 +220,60 @@ exports.get_filetype_reader  = {
 exports.non_existing = {
     setUp: _set_up,
 
-    'empty object for JSON files': function(test) {
+    'empty object for JSON files': function (test) {
         test.expect(1);
-        var result = this.cfreader.load_config(
-                'test/config/non-existent.json'
-                );
+        const result = this.cfreader.load_config(
+            'test/config/non-existent.json'
+        );
         test.deepEqual(result, {});
         test.done();
     },
-    'empty object for YAML files': function(test) {
+    'empty object for YAML files': function (test) {
         test.expect(1);
-        var result = this.cfreader.load_config(
-                'test/config/non-existent.yaml'
-                );
+        const result = this.cfreader.load_config(
+            'test/config/non-existent.yaml'
+        );
         test.deepEqual(result, {});
         test.done();
     },
-    'null for binary file': function(test) {
+    'null for binary file': function (test) {
         test.expect(1);
-        var result = this.cfreader.load_config(
-                'test/config/non-existent.bin',
-                'binary'
-                );
+        const result = this.cfreader.load_config(
+            'test/config/non-existent.bin',
+            'binary'
+        );
         test.equal(result, null);
         test.done();
     },
-    'null for flat file': function(test) {
+    'null for flat file': function (test) {
         test.expect(1);
-        var result = this.cfreader.load_config(
-                'test/config/non-existent.flat'
-                );
+        const result = this.cfreader.load_config(
+            'test/config/non-existent.flat'
+        );
         test.deepEqual(result, null);
         test.done();
     },
-    'null for value file': function(test) {
+    'null for value file': function (test) {
         test.expect(1);
-        var result = this.cfreader.load_config(
-                'test/config/non-existent.value'
-                );
+        const result = this.cfreader.load_config(
+            'test/config/non-existent.value'
+        );
         test.deepEqual(result, null);
         test.done();
     },
-    'empty array for list file': function(test) {
+    'empty array for list file': function (test) {
         test.expect(1);
-        var result = this.cfreader.load_config(
+        const result = this.cfreader.load_config(
             'test/config/non-existent.list'
-            );
+        );
         test.deepEqual(result, []);
         test.done();
     },
-    'template ini for INI file': function(test) {
+    'template ini for INI file': function (test) {
         test.expect(1);
-        var result = this.cfreader.load_config(
-                'test/config/non-existent.ini'
-                );
+        const result = this.cfreader.load_config(
+            'test/config/non-existent.ini'
+        );
         test.deepEqual(result, { main: {} });
         test.done();
     },
@@ -377,7 +377,7 @@ exports.bad_config = {
     setUp: _set_up,
     'bad.yaml returns empty' : function (test) {
         test.expect(1);
-        var res = this.cfreader.load_config('test/config/bad.yaml');
+        const res = this.cfreader.load_config('test/config/bad.yaml');
         test.deepEqual(res, {});
         test.done();
     },


### PR DESCRIPTION
- add process.env.HARAKA_TEST_DIR support (synced from haraka/Haraka/config.js)
- lint updates for tests
- add `__dirname/../../config` to config_dir_candidates (for haraka/Haraka/*.js)