### PR TITLE
test: if $config.json missing, load $config.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-    - "4"
     - "6"
+    - "8"
 
 before_script:
 

--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,8 @@
 - additional test for 'missing json loads yaml'
 - modify get_path_to_config_dir regex to also match windows paths
 - add tests for get_path_to_config_dir
+- configs w/o .ext or declared type default to flat
+- add test for json/yaml !filename overloads
 
 ## 1.0.14 - 2017-09-19
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,10 @@
 
+## 1.0.15 - 2017-09-21
+
+- additional test for 'missing json loads yaml'
+- modify get_path_to_config_dir regex to also match windows paths
+- add tests for get_path_to_config_dir
+
 ## 1.0.14 - 2017-09-19
 
 - add __dirname/../../config to config_dir_candidates for haraka/Haraka/tests/*

--- a/configfile.js
+++ b/configfile.js
@@ -35,7 +35,7 @@ let config_dir_candidates = [
     __dirname,                         // npm packaged plugins
 ];
 
-function get_path_to_config_dir () {
+cfreader.get_path_to_config_dir = function () {
     if (process.env.HARAKA) {
         // console.log('process.env.HARAKA: ' + process.env.HARAKA);
         cfreader.config_path = path.join(process.env.HARAKA, 'config');
@@ -49,7 +49,7 @@ function get_path_to_config_dir () {
     }
 
     // these work when this is loaded with require('haraka-config')
-    if (/node_modules\/haraka-config$/.test(__dirname)) {
+    if (/node_modules[\\/]haraka-config$/.test(__dirname)) {
         config_dir_candidates = [
             path.join(__dirname, '..', '..', 'config'),  // haraka/Haraka/*
             path.join(__dirname, '..', '..'),            // npm packaged modules
@@ -70,7 +70,7 @@ function get_path_to_config_dir () {
         }
     }
 }
-get_path_to_config_dir();
+exports.get_path_to_config_dir();
 // console.log('cfreader.config_path: ' + cfreader.config_path);
 
 cfreader.on_watch_event = function (name, type, options, cb) {
@@ -164,26 +164,22 @@ cfreader.watch_file = function (name, type, cb, options) {
 };
 
 cfreader.get_cache_key = function (name, options) {
-    let result;
 
     // Ignore options etc. if this is an overriden value
-    if (cfreader._overrides[name]) {
-        result = name;
-    }
-    else if (options) {
+    if (cfreader._overrides[name]) return name;
+
+    if (options) {
         // this ordering of objects isn't guaranteed to be consistent, but I've
         // heard that it typically is.
-        result = name + JSON.stringify(options);
-    }
-    else if (cfreader._read_args[name] && cfreader._read_args[name].options) {
-        result = name + JSON.stringify(cfreader._read_args[name].options);
-    }
-    else {
-        result = name;
+        return name + JSON.stringify(options);
     }
 
-    return result;
-};
+    if (cfreader._read_args[name] && cfreader._read_args[name].options) {
+        return name + JSON.stringify(cfreader._read_args[name].options);
+    }
+
+    return name;
+}
 
 cfreader.read_config = function (name, type, cb, options) {
     // Store arguments used so we can:

--- a/configfile.js
+++ b/configfile.js
@@ -317,8 +317,12 @@ cfreader.ensure_enoent_timer = function () {
 };
 
 cfreader.get_filetype_reader = function (type) {
-    if (/^(list|value|data)$/.test(type)) {
-        return require('./readers/flat');
+    switch (type) {
+        case 'list':
+        case 'value':
+        case 'data':
+        case '':
+            return require('./readers/flat');
     }
     return require('./readers/' + type);
 };
@@ -389,15 +393,14 @@ cfreader.process_file_overrides = function (name, options, result) {
         }
     }
 
-    // Allow JSON files to create or overwrite other
-    // configuration file data by prefixing the
-    // outer variable name with ! e.g. !smtp.ini
+    // Allow JSON files to create or overwrite other config file data
+    // by prefixing the outer variable name with ! e.g. !smtp.ini
     const keys = Object.keys(result);
     for (let j=0; j<keys.length; j++) {
         if (keys[j].substr(0,1) !== '!') continue;
         const fn = keys[j].substr(1);
         // Overwrite the config cache for this filename
-        console.log('Overriding file ' + fn + ' with config from ' + name);
+        console.log(`Overriding file ${fn} with config from ${name}`);
         cfreader._config_cache[path.join(cp, fn)] = result[keys[j]];
     }
 };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "haraka-config",
   "license": "MIT",
   "description": "Haraka's config file loader",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "homepage": "http://haraka.github.io",
   "repository": {
     "type": "git",

--- a/run_tests
+++ b/run_tests
@@ -2,33 +2,30 @@
 
 'use strict';
 
+let reporter
+
 try {
-    var reporter = require('nodeunit').reporters.default;
+    reporter = require('nodeunit').reporters.default
 }
-catch(e) {
-    console.log("Error: " + e.message);
-    console.log("");
-    console.log("Cannot find nodeunit module.");
-    console.log("Please run the following:");
-    console.log("");
-    console.log("    npm install");
-    console.log("");
-    process.exit();
+catch (e) {
+    console.log(`Error: ${e.message}
+
+Please run the following:
+
+    npm install
+`);
+    process.exit()
 }
 
-process.chdir(__dirname);
+process.chdir(__dirname)
+
+let testDirs = [ 'test', 'test/readers'];
 
 if (process.argv[2]) {
-    console.log("Running tests: ", process.argv.slice(2));
-    reporter.run(process.argv.slice(2), undefined, function (err) {
-        process.exit(((err) ? 1 : 0));
-    });
+    testDirs = process.argv.slice(2);
+    console.log(`Running tests: ${testDirs}`)
 }
-else {
-    reporter.run([
-        'test',
-        'test/readers',
-    ], undefined, function (err) {
-        process.exit(((err) ? 1 : 0));
-    });
-}
+
+reporter.run(testDirs, undefined, (err) => {
+    process.exit(((err) ? 1 : 0))
+})

--- a/test/config.js
+++ b/test/config.js
@@ -375,6 +375,12 @@ exports.getDir = {
         })
     },
     'reloads when file in dir is touched' : function (test) {
+        if (/darwin/.test(process.platform)) {
+            // due to differences in fs.watch, this test is not reliable on
+            // Mac OS X
+            test.done();
+            return;
+        }
         test.expect(6);
         const self = this;
         let callCount = 0;

--- a/test/config.js
+++ b/test/config.js
@@ -1,7 +1,5 @@
 'use strict';
 
-process.env.NODE_ENV = 'test'
-
 const fs   = require('fs');
 const path = require('path');
 
@@ -21,6 +19,7 @@ function clearRequireCache () {
 }
 
 function setUp (done) {
+    process.env.NODE_ENV = 'test'
     process.env.HARAKA = '';
     clearRequireCache();
     this.config = require('../config');
@@ -410,5 +409,28 @@ exports.getDir = {
             self.config.getDir('dir', opts2, getDirDone);
         }
         getDir();
+    }
+}
+
+exports.jsonOverrides = {
+    'setUp' : setUp,
+    'no override for smtpgreeting': function (test) {
+        test.expect(1);
+        // console.log(this.config);
+        test.deepEqual(
+            this.config.get('smtpgreeting', 'list'),
+            []
+        );
+        test.done();
+    },
+    'with smtpgreeting override': function (test) {
+        test.expect(1);
+        const main = this.config.get('main.json');
+        console.log(main);
+        test.deepEqual(
+            this.config.get('smtpgreeting', 'list'),
+            [ 'this is line one', 'this is line two' ]
+        );
+        test.done();
     }
 }

--- a/test/config/main.json
+++ b/test/config/main.json
@@ -1,0 +1,3 @@
+{
+    "!smtpgreeting": [ "this is line one", "this is line two" ]
+}

--- a/test/config/override.yaml
+++ b/test/config/override.yaml
@@ -1,0 +1,2 @@
+has:
+  value: true

--- a/test/configfile.js
+++ b/test/configfile.js
@@ -1,6 +1,6 @@
 'use strict';
 
-process.env.NODE_ENV === 'test';
+// process.env.NODE_ENV === 'test';
 
 const _set_up = function (done) {
     this.cfreader = require('../configfile');
@@ -392,6 +392,34 @@ exports.overrides = {
         test.deepEqual(
             this.cfreader.load_config('test/config/override.json'),
             { has: { value: true } });
+        test.done();
+    },
+}
+
+exports.get_path_to_config_dir = {
+    setUp: _set_up,
+    'Haraka runtime (env.HARAKA=*)' : function (test) {
+        test.expect(1);
+        process.env.HARAKA = '/etc/';
+        this.cfreader.get_path_to_config_dir();
+        test.ok(/etc.config$/.test(this.cfreader.config_path), this.cfreader.config_path);
+        delete process.env.HARAKA;
+        test.done();
+    },
+    'env.NODE_ENV=test' : function (test) {
+        test.expect(1);
+        process.env.NODE_ENV === 'test';
+        this.cfreader.get_path_to_config_dir();
+        test.ok(/haraka-config.test.config$/.test(this.cfreader.config_path), this.cfreader.config_path);
+        delete process.env.NODE_ENV;
+        test.done();
+    },
+    'no $ENV defaults to ./config (if present) or ./' : function (test) {
+        test.expect(1);
+        delete process.env.HARAKA;
+        delete process.env.NODE_ENV;
+        this.cfreader.get_path_to_config_dir();
+        test.ok(/haraka-config$/.test(this.cfreader.config_path), this.cfreader.config_path);
         test.done();
     },
 }

--- a/test/configfile.js
+++ b/test/configfile.js
@@ -1,15 +1,16 @@
 'use strict';
 
-// process.env.NODE_ENV === 'test';
+// const path = require('path');
 
-const _set_up = function (done) {
+function _setUp (done) {
+    process.env.NODE_ENV === 'test';
     this.cfreader = require('../configfile');
     this.opts = { booleans: ['main.bool_true','main.bool_false'] };
     done();
-};
+}
 
 exports.load_config = {
-    setUp: _set_up,
+    setUp: _setUp,
     'non-exist.ini empty' : function (test) {
         test.expect(1);
         test.deepEqual(
@@ -158,7 +159,7 @@ exports.load_config = {
 };
 
 exports.get_filetype_reader  = {
-    setUp: _set_up,
+    setUp: _setUp,
     'binary': function (test) {
         test.expect(2);
         const reader = this.cfreader.get_filetype_reader('binary');
@@ -218,7 +219,7 @@ exports.get_filetype_reader  = {
 };
 
 exports.non_existing = {
-    setUp: _set_up,
+    setUp: _setUp,
 
     'empty object for JSON files': function (test) {
         test.expect(1);
@@ -280,7 +281,7 @@ exports.non_existing = {
 };
 
 exports.get_cache_key = {
-    setUp: _set_up,
+    setUp: _setUp,
     'no options is the name': function (test) {
         test.expect(1);
         test.equal(this.cfreader.get_cache_key('test'),
@@ -303,7 +304,7 @@ exports.get_cache_key = {
 };
 
 exports.regex = {
-    setUp: _set_up,
+    setUp: _setUp,
     'section': function (test) {
         test.expect(4);
         test.equal(this.cfreader.regex.section.test('[foo]'), true);
@@ -374,7 +375,7 @@ exports.regex = {
 }
 
 exports.bad_config = {
-    setUp: _set_up,
+    setUp: _setUp,
     'bad.yaml returns empty' : function (test) {
         test.expect(1);
         test.deepEqual(
@@ -386,7 +387,7 @@ exports.bad_config = {
 }
 
 exports.overrides = {
-    setUp: _set_up,
+    setUp: _setUp,
     'missing json loads yaml instead' : function (test) {
         test.expect(1);
         test.deepEqual(
@@ -397,7 +398,7 @@ exports.overrides = {
 }
 
 exports.get_path_to_config_dir = {
-    setUp: _set_up,
+    setUp: _setUp,
     'Haraka runtime (env.HARAKA=*)' : function (test) {
         test.expect(1);
         process.env.HARAKA = '/etc/';
@@ -406,7 +407,7 @@ exports.get_path_to_config_dir = {
         delete process.env.HARAKA;
         test.done();
     },
-    'env.NODE_ENV=test' : function (test) {
+    'NODE_ENV=test' : function (test) {
         test.expect(1);
         process.env.NODE_ENV === 'test';
         this.cfreader.get_path_to_config_dir();

--- a/test/configfile.js
+++ b/test/configfile.js
@@ -377,8 +377,21 @@ exports.bad_config = {
     setUp: _set_up,
     'bad.yaml returns empty' : function (test) {
         test.expect(1);
-        const res = this.cfreader.load_config('test/config/bad.yaml');
-        test.deepEqual(res, {});
+        test.deepEqual(
+            this.cfreader.load_config('test/config/bad.yaml'),
+            {}
+        );
+        test.done();
+    },
+}
+
+exports.overrides = {
+    setUp: _set_up,
+    'missing json loads yaml instead' : function (test) {
+        test.expect(1);
+        test.deepEqual(
+            this.cfreader.load_config('test/config/override.json'),
+            { has: { value: true } });
         test.done();
     },
 }


### PR DESCRIPTION
- additional test for 'missing json loads yaml'
- **modify get_path_to_config_dir regex to also match windows paths (\ vs / path separator)**
- add tests for get_path_to_config_dir
- configs w/o .ext or declared type default to flat
- add test for !filename overloads