### PR TITLE
getDir: test indicates file contents are buffer

### DIFF
--- a/.github/workflows/ci-test-win.yml
+++ b/.github/workflows/ci-test-win.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest ]
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
       fail-fast: false
 
     steps:

--- a/readers/binary.js
+++ b/readers/binary.js
@@ -7,7 +7,7 @@ exports.load = (name) => {
 }
 
 exports.loadPromise = (name) => {
-    return new Promise(function (resolve, reject) {
+    return new Promise((resolve, reject) => {
         fs.readFile(name, (err, content) => {
             if (err) return reject(err);
             resolve({ path: name, data: content });

--- a/readers/flat.js
+++ b/readers/flat.js
@@ -52,7 +52,7 @@ exports.load = (name, type, options, regex) => {
     return result;
 }
 
-exports.empty = function (options, type) {
+exports.empty = (options, type) => {
     switch (type) {
         case 'flat':
         case 'value':

--- a/test/config.js
+++ b/test/config.js
@@ -1,7 +1,8 @@
 
 const assert = require('assert')
-const fs     = require('fs');
-const path   = require('path');
+const fs     = require('fs')
+const os     = require('os')
+const path   = require('path')
 
 function cb () { return false; }
 const opts = { booleans: ['arg1'] };
@@ -468,8 +469,8 @@ describe('getDir', function () {
             // console.log(files);
             assert.equal(err, null);
             assert.equal(files.length, 3);
-            assert.equal(files[0].data.toString(), 'contents1\n');
-            assert.equal(files[2].data.toString(), 'contents3\n');
+            assert.equal(files[0].data.toString(), `contents1${os.EOL}`);
+            assert.equal(files[2].data.toString(), `contents3${os.EOL}`);
             done();
         })
     })
@@ -499,8 +500,8 @@ describe('getDir', function () {
                 // console.log(files);
                 assert.equal(err, null);
                 assert.equal(files.length, 3);
-                assert.equal(files[0].data, 'contents1\n');
-                assert.equal(files[2].data, 'contents3\n');
+                assert.equal(files[0].data, `contents1${os.EOL}`);
+                assert.equal(files[2].data, `contents3${os.EOL}`);
                 fs.writeFile(tmpFile, 'contents4\n', (err2, res) => {
                     assert.equal(err2, null);
                     // console.log('file touched, waiting for callback');

--- a/test/config.js
+++ b/test/config.js
@@ -464,11 +464,12 @@ describe('getDir', function () {
 
     it('loads all files in dir', function (done) {
         this.config.getDir('dir', { type: 'binary' }, (err, files) => {
+            assert.ifError(err);
             // console.log(files);
             assert.equal(err, null);
             assert.equal(files.length, 3);
-            assert.equal(files[0].data, 'contents1\n');
-            assert.equal(files[2].data, 'contents3\n');
+            assert.equal(files[0].data.toString(), 'contents1\n');
+            assert.equal(files[2].data.toString(), 'contents3\n');
             done();
         })
     })

--- a/test/config.js
+++ b/test/config.js
@@ -469,8 +469,8 @@ describe('getDir', function () {
             // console.log(files);
             assert.equal(err, null);
             assert.equal(files.length, 3);
-            assert.equal(files[0].data.toString(), `contents1${os.EOL}`);
-            assert.equal(files[2].data.toString(), `contents3${os.EOL}`);
+            assert.equal(files[0].data, `contents1${os.EOL}`);
+            assert.equal(files[2].data, `contents3${os.EOL}`);
             done();
         })
     })


### PR DESCRIPTION
test failures showed Buffer vs string in ==. After toString(), I could see it was `contents1\r\n == contents1\n`. So replace `\n` with `${os.EOL}` and tests pass. 

fixes #55 