### PR TITLE
Fix json overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Overrides work in the following manner:
   key by key basis.
 - For every other config format, an override file replaces the entire
   config.
+- If `smtp.json` or `smtp.yaml` exist, their contents will be loaded before all other config files. You can make use of [JSON Overrides](#json-overrides) here for a single file config.
 
 ## Examples
 
@@ -243,15 +244,28 @@ These are as you would expect, and returns an object as given in the file.
 
 If a requested .json or .hjson file does not exist then the same file will be checked for with a .yaml extension and that will be loaded instead. This is done because YAML files are far easier for a human to write.
 
+### <a name="json-overrides">JSON Overrides</a>
 You can use JSON, HJSON or YAML files to override any other file by prefixing the outer variable name with a `!` e.g.
 
 ```js
 {
-    "!smtpgreeting": [ 'this is line one', 'this is line two' ]
+  "!smtpgreeting": ['this is line one', 'this is line two'],
+  "!smtp.ini": {
+    main: {
+      nodes: 0,
+    },
+    headers: {
+      max_lines: 1000,
+      max_received: 100,
+    },
+  },
+  "!custom-plugin.yaml": {
+    secret: 'example',
+  },
 }
 ```
 
-If the config/smtpgreeting file did not exist, then this value would replace it.
+If the config/smtpgreeting wasn't loaded before, then this value would replace it. Since `smtp.json` is always loaded first, it can be used to override existing config files.
 
 NOTE: You must ensure that the data type (e.g. Object, Array or String) for the replaced value is correct. This cannot be done automatically.
 

--- a/config.js
+++ b/config.js
@@ -158,5 +158,5 @@ function merge_struct(defaults, overrides) {
   return defaults
 }
 
-// Load smtp.json or smtp.yaml as early as possible
+// JSON overrides needs smtp.(json|yaml) loaded early
 module.exports.get('smtp.json');

--- a/config.js
+++ b/config.js
@@ -157,3 +157,6 @@ function merge_struct(defaults, overrides) {
   }
   return defaults
 }
+
+// Load smtp.json or smtp.yaml as early as possible
+module.exports.get('smtp.json');

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -245,7 +245,9 @@ class Reader {
       const fn = key.substr(1)
       // Overwrite the config cache for this filename
       console.log(`Overriding file ${fn} with config from ${name}`)
-      this._config_cache[path.join(cp, fn)] = result[key]
+      const cache_key = path.join(cp, fn)
+      this._overrides[cache_key] = true
+      this._config_cache[cache_key] = result[key]
     }
   }
 }


### PR DESCRIPTION
Found some vague references to a single file config option. After figuring out how to use, it didn't really seem to work. So I dug in and fixed it!

- Loading `smtp.json` seems to have been accidentally removed in this commit 8 years ago from what I can tell:
  https://github.com/haraka/Haraka/commit/fefae7cdfca43241182ffe2be3f60091a547ca69
- `this._overrides` was checked, but there wasn't any code setting values there. Must have been accidentally removed at some point as well.
- Also added some more details/example to the doc for using this so there's less to figure out.

Fixes #69
Fixes #68
Fixes #66