### PR TITLE
Fix TypeError caused by using 'in' operator on null

### DIFF
--- a/config.js
+++ b/config.js
@@ -141,6 +141,7 @@ const isObject = (v) => typeof v === 'object' && v !== null
 function merge_struct(defaults, overrides) {
   for (const k in overrides) {
     if (['__proto__', 'constructor'].includes(k)) continue
+    if (overrides[k] === null) continue
     if (k in defaults) {
       if (isObject(overrides[k]) && isObject(defaults[k])) {
         defaults[k] = merge_struct(defaults[k], overrides[k])

--- a/config.js
+++ b/config.js
@@ -136,11 +136,13 @@ function merge_config(defaults, overrides, type) {
   return defaults
 }
 
+const isObject = (v) => typeof v === 'object' && v !== null
+
 function merge_struct(defaults, overrides) {
   for (const k in overrides) {
     if (['__proto__', 'constructor'].includes(k)) continue
     if (k in defaults) {
-      if (typeof overrides[k] === 'object' && typeof defaults[k] === 'object') {
+      if (isObject(overrides[k]) && isObject(defaults[k])) {
         defaults[k] = merge_struct(defaults[k], overrides[k])
       } else {
         defaults[k] = overrides[k]


### PR DESCRIPTION
In javascript, `typeof(null) === 'object'`, but using `if 'var' in null` triggers TypeError. 

It could happen, that default configuration has struct member value `null`, i.e. when YAML configuration has an empty value:
```yaml
plugins:
```
Trying to override such value with:
```yaml
plugins:
  rspamd:
    enabled: true
```
causes configuration reader to fail:
```
[CRIT] [-] [core] TypeError: Cannot use 'in' operator to search for 'rspamd' in null
[CRIT] [-] [core]     at merge_struct (/opt/haraka/node_modules/haraka-config/config.js:142:11)
[CRIT] [-] [core]     at merge_struct (/opt/haraka/node_modules/haraka-config/config.js:144:23)
[CRIT] [-] [core]     at merge_config (/opt/haraka/node_modules/haraka-config/config.js:127:14)
[CRIT] [-] [core]     at Config.get (/opt/haraka/node_modules/haraka-config/config.js:35:17)
...
```
This PR adds null check.